### PR TITLE
Update README.md documentation for FastCGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ file extension (`.fcgi`). For more advanced configurations, consult your web ser
 
 1. Build `mod_fastcgi`:
 
-        $ brew install mod_fastcgi
+        $ brew install homebrew/apache/mod_fastcgi
 
    Verify that the module was installed; in my configuration, the binary was in
 


### PR DESCRIPTION
Fix FastCGI installation documentation but actually mod_fastcgi install from Homebrew is broken an issue is open about it.

https://github.com/Homebrew/homebrew-apache/issues/104
